### PR TITLE
Favorite Swatches

### DIFF
--- a/ColorPicker/ColorPickerViewController.swift
+++ b/ColorPicker/ColorPickerViewController.swift
@@ -13,9 +13,13 @@ class ColorPickerViewController: NSViewController {
     var colorPanel: NSColorPanel?
     
     override func loadView() {
+        
         if NSColorPanel.sharedColorPanelExists() && NSColorPanel.shared().isVisible {
+            
             NSColorPanel.shared().orderOut(self)
+            
         }
+        
         colorPanel = NSColorPanel.shared()
         colorPanel?.showsAlpha = true
         let paletteItem = colorPanel?.toolbar?.items[0]
@@ -23,6 +27,39 @@ class ColorPickerViewController: NSViewController {
         self.view = colorPanel!.contentView!
         colorPanel!.contentView!.frame = NSMakeRect(0, 0, view.frame.width, view.frame.height)
         colorPanel!.contentView!.autoresizingMask = [.viewWidthSizable, .viewHeightSizable]
+        
+        if let swatch = locateColorSwatch() {
+            
+            swatch.perform(NSSelectorFromString("updateSwatch"))
+            
+        }
+        
+    }
+    
+    func locateColorSwatch() -> NSView? {
+        
+        func findSwatchInSubviews(v: NSView) -> NSView? {
+            
+            for subview in v.subviews {
+                
+                if subview.className == "NSColorSwatch" {
+                    
+                    return subview
+                    
+                } else if let foundView = findSwatchInSubviews(v: subview) {
+                    
+                    return foundView
+                    
+                }
+                
+            }
+            
+            return nil
+            
+        }
+        
+        return findSwatchInSubviews(v: self.view)
+        
     }
     
 }


### PR DESCRIPTION
Added code to fix a bug where favorite color swatches weren’t being loaded when the panel is displayed. Resolves issue #1. The function `locateColorSwatch()` returns the first instance of undocumented NSColorSwatch view. If found in the modified `loadView()`, it’s asked to perform the undocumented `-[NSColorSwatch updateSwatch]` selector.